### PR TITLE
WIP Header bug fix

### DIFF
--- a/ODIN_II/SRC/include/odin_util.h
+++ b/ODIN_II/SRC/include/odin_util.h
@@ -22,6 +22,7 @@ const char* ast_node_name_based_on_ids(ast_node_t* node);
 char* make_signal_name(char* signal_name, int bit);
 char* make_full_ref_name(const char* previous, const char* module_name, const char* module_instance_name, const char* signal_name, long bit);
 char* make_full_name_w_o_array_ref(const char* previous, const char* module_name, const char* module_instance_name);
+bool output_vector_headers_equal(char* buffer1, char* buffer2);
 
 char* twos_complement(char* str);
 int is_string_of_radix(char* string, int radix);

--- a/ODIN_II/SRC/odin_util.cpp
+++ b/ODIN_II/SRC/odin_util.cpp
@@ -909,6 +909,57 @@ void trim_string(char* string, const char* chars) {
     }
 }
 
+/*
+ * Tokenizes a string and returns an array where each element is a 
+ * token and a pointer (that needs to be passed through) with the 
+ * size of the array
+*/
+static char** string_to_token_array(char* string, int* size) {
+    char** arr = NULL;
+
+    char* token = strtok(string, " \n\t");
+    int i = 0;
+
+    while (token != NULL) {
+        arr = (char**)vtr::realloc(arr, sizeof(char*) * (i + 1));
+        arr[i] = token;
+        token = strtok(NULL, " \n\t");
+        i++;
+    }
+    *size = (i);
+    return arr;
+}
+
+/*
+ * Will seperate the headers from the inputs and compare them
+ * Will return value of 1 if they match and 0 if
+ * they don't match. Possible error if the vector headers match
+ * but are in different order
+ */
+bool output_vector_headers_equal(char* buffer1, char* buffer2) {
+    int size1 = 0;
+    int size2 = 0;
+    char* buffer1_copy = strdup(buffer1);
+    char* buffer2_copy = strdup(buffer2);
+
+    char** header1 = string_to_token_array(buffer1_copy, &size1);
+    char** header2 = string_to_token_array(buffer2_copy, &size2);
+
+    int i = 0;
+    bool header_matches;
+
+    header_matches = (size1 == size2);
+    for (i = 0; header_matches && i < (size1 - 1); i++) {
+        header_matches = (0 == strcmp(header1[i], header2[i]));
+    }
+
+    vtr::free(header1);
+    vtr::free(header2);
+    free(buffer1_copy);
+    free(buffer2_copy);
+    return (header_matches);
+}
+
 /**
  * verifies only one condition evaluates to true
  */

--- a/ODIN_II/SRC/simulate_blif.cpp
+++ b/ODIN_II/SRC/simulate_blif.cpp
@@ -2225,36 +2225,37 @@ static int verify_test_vector_headers(FILE* in, lines_t* l) {
     char buffer[BUFFER_MAX_SIZE];
     buffer[0] = '\0';
     unsigned int i;
-    for (i = 0; i < strlen(read_buffer) && i < BUFFER_MAX_SIZE; i++) {
-        char next = read_buffer[i];
+    for (i = 0; i < strlen(read_buffer) && i < BUFFER_MAX_SIZE; i++) ]
+    {
+            char next = read_buffer[i];
 
-        if (next == EOF) {
-            warning_message(SIMULATION, 0, -1, "%s", "Hit end of file.");
-            return false;
-        } else if (next == ' ' || next == '\t' || next == '\n') {
-            if (buffer_length) {
-                if (strcmp(l->lines[current_line]->name, buffer)) {
-                    char* expected_header = generate_vector_header(l);
-                    warning_message(SIMULATION, 0, -1,
-                                    "Vector header mismatch: \n "
-                                    "  Found:    %s "
-                                    "  Expected: %s",
-                                    read_buffer, expected_header);
-                    vtr::free(expected_header);
-                    return false;
-                } else {
-                    buffer_length = 0;
-                    current_line++;
+            if (next == EOF) {
+                warning_message(SIMULATION, 0, -1, "%s", "Hit end of file.");
+                return false;
+            } else if (next == ' ' || next == '\t' || next == '\n') {
+                if (buffer_length) {
+                    if (strcmp(l->lines[current_line]->name, buffer)) {
+                        char* expected_header = generate_vector_header(l);
+                        warning_message(SIMULATION, 0, -1,
+                                        "Vector header mismatch: \n "
+                                        "  Found:    %s "
+                                        "  Expected: %s",
+                                        read_buffer, expected_header);
+                        vtr::free(expected_header);
+                        return false;
+                    } else {
+                        buffer_length = 0;
+                        current_line++;
+                    }
                 }
-            }
 
-            if (next == '\n')
-                break;
-        } else {
-            buffer[buffer_length++] = next;
-            buffer[buffer_length] = '\0';
+                if (next == '\n')
+                    break;
+            } else {
+                buffer[buffer_length++] = next;
+                buffer[buffer_length] = '\0';
+            }
         }
-    }
     return true;
 }
 
@@ -2727,7 +2728,7 @@ static int verify_output_vectors(const char* output_vector_file, int num_vectors
                 break;
             }
             // The headers differ.
-            else if ((cycle == -1) && strcmp(buffer1, buffer2)) {
+            else if ((cycle == -1) && !output_vector_headers_equal(buffer1, buffer2)) {
                 error = true;
                 warning_message(SIMULATION, 0, -1,
                                 "Vector headers do not match: \n"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

In simulation_bliff.cpp I'm modifying it so it trims the header vector files read from an inputed vector file because when comparing it received errors even if the titles were the same.

#### Related Issue
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

There is an open issue but ont the original vtr but not on CAS-Atlantic. I raised the issue (emacdo12)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It's just an annoying bug

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test cases that reproduce the bug have been implemented

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
