### PR TITLE
[WIP] Odin droping outputs with initial value

### DIFF
--- a/ODIN_II/SRC/netlist_create_from_ast.cpp
+++ b/ODIN_II/SRC/netlist_create_from_ast.cpp
@@ -1034,6 +1034,18 @@ nnet_t* define_nets_with_driver(ast_node_t* var_declare, char* instance_name_pre
 
             if (var_declare->types.variable.initial_value) {
                 new_net->initial_value = (init_value_e)var_declare->types.variable.initial_value->get_bit_from_lsb(i);
+
+                npin_t* new_pin = allocate_npin();
+                if (new_net->initial_value == _0) {
+                    allocate_more_output_pins(verilog_netlist->gnd_node, 1);
+                    add_output_pin_to_node(verilog_netlist->gnd_node, new_pin, verilog_netlist->gnd_node->num_output_pins - 1);
+
+                } else if (new_net->initial_value == _1) {
+                    allocate_more_output_pins(verilog_netlist->vcc_node, 1);
+                    add_output_pin_to_node(verilog_netlist->vcc_node, new_pin, verilog_netlist->vcc_node->num_output_pins - 1);
+                }
+
+                add_driver_pin_to_net(new_net, new_pin);
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
After adding an initial value container for each net in this [commit](https://github.com/CAS-Atlantic/vtr-verilog-to-routing/commit/f09143a8af7cc03c391939f6dd5499a11f1215f7#diff-aa3304faea319175b58a1f91e51f364b), the final outputs would be undriven since their net do not have any driver pin.
In this PR, this problem has been solved by connecting nets of those undriven outputs to related initial value node, i.e.VCC or GND.

#### Related Issue
#1366
<!--- Pull requests should be related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Uding odin execution file with provided test case in the aforementioned issue.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
